### PR TITLE
Update Json payload for sending teams notification

### DIFF
--- a/Azure/AppSecretExpiration_SendtoTeams.ps1
+++ b/Azure/AppSecretExpiration_SendtoTeams.ps1
@@ -103,12 +103,18 @@ foreach ($app in $apps) {
 if ($array.count -ne 0) {
     Write-output "Sending Teams Message"
     $textTable = $array | Sort-Object daysUntil | select-object displayName, secretName, daysUntil | ConvertTo-Html
-    $JSONBody = [PSCustomObject][Ordered]@{
-        "@type"      = "MessageCard"
-        "@context"   = "<http://schema.org/extensions>"
-        "themeColor" = '0078D7'
-        "title"      = "$($Array.count) App Secrets areExpiring Soon"
-        "text"       = "$textTable"
+    $JSONBody = @{
+        type = "message"
+        attachments = @(
+            @{
+                contentType = "$textTable"
+                content = @{
+                    "$schema" = "http://adaptivecards.io/schemas/adaptive-card.json"
+                    type = "AdaptiveCard"
+                    version = "1.2"
+                }
+            }
+        )
     }
 
     $TeamMessageBody = ConvertTo-Json $JSONBody


### PR DESCRIPTION
Following the recent news of deprecation of O365 connectors by Microsoft, teams now requires power platform workflows to handle webhooks sent to teams.

https://powerusers.microsoft.com/t5/General-Power-Automate/Teams-Workflow-Post-to-a-channel-when-a-webhook-request-is/m-p/2838097